### PR TITLE
Add worker demo and worker-friendly utilities

### DIFF
--- a/sandbox/offscreen_worker/index.html
+++ b/sandbox/offscreen_worker/index.html
@@ -1,0 +1,15 @@
+<html>
+<head>
+    <title>Offscreen Worker Globe</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script src="./index.js" type="module"></script>
+    <link rel="stylesheet" href="../../css/og.css" type="text/css" />
+    <style>
+        body { margin: 0; padding: 0; }
+    </style>
+</head>
+<body>
+<div id="earth" style="position:absolute;width:100%;height:100%"></div>
+</body>
+</html>

--- a/sandbox/offscreen_worker/index.js
+++ b/sandbox/offscreen_worker/index.js
@@ -1,0 +1,4 @@
+const canvas = document.getElementById('earth');
+const worker = new Worker('./worker.js', {type: 'module'});
+const offscreen = canvas.transferControlToOffscreen();
+worker.postMessage({type: 'init', canvas: offscreen}, [offscreen]);

--- a/sandbox/offscreen_worker/worker.js
+++ b/sandbox/offscreen_worker/worker.js
@@ -1,0 +1,19 @@
+import {Globe, control, OpenStreetMap, GlobusRgbTerrain, Bing} from "../../lib/og.es.js";
+
+let globe = null;
+
+self.onmessage = (e) => {
+    if (e.data.type === 'init') {
+        const canvas = e.data.canvas;
+        globe = new Globe({
+            target: canvas,
+            name: 'Earth',
+            terrain: new GlobusRgbTerrain(),
+            layers: [new OpenStreetMap(), new Bing()],
+            atmosphereEnabled: false,
+            fontsSrc: '../../res/fonts'
+        });
+        globe.planet.addControl(new control.TimelineControl());
+        globe.planet.addControl(new control.LayerSwitcher());
+    }
+};

--- a/src/control/timeline/TimelineModel.ts
+++ b/src/control/timeline/TimelineModel.ts
@@ -1,5 +1,6 @@
 import {type EventsHandler, createEvents} from '../../Events';
 import {addSeconds} from "./timelineUtils";
+import {raf, caf} from '../../utils/raf';
 
 type TimelineEventsList = ["change", "current"];
 
@@ -49,14 +50,14 @@ class TimelineModel {
 
     public play() {
         if (!this._requestAnimationFrameId) {
-            this._prevNow = window.performance.now();
+            this._prevNow = performance.now();
             this._animationFrameCallback();
         }
     }
 
     public stop() {
         if (this._requestAnimationFrameId) {
-            window.cancelAnimationFrame(this._requestAnimationFrameId);
+            caf(this._requestAnimationFrameId);
             this._requestAnimationFrameId = 0;
         }
     }
@@ -66,14 +67,14 @@ class TimelineModel {
     }
 
     protected _animationFrameCallback() {
-        this._requestAnimationFrameId = window.requestAnimationFrame(() => {
+        this._requestAnimationFrameId = raf(() => {
             this._frame();
             this._animationFrameCallback();
         });
     }
 
     protected _frame() {
-        let now = window.performance.now();
+        let now = performance.now();
         this.dt = now - this._prevNow;
         this._prevNow = now;
 

--- a/src/quadTree/Node.ts
+++ b/src/quadTree/Node.ts
@@ -403,7 +403,7 @@ class Node {
             // store fading nodes, could be a parent or children nodes
             this._fadingNodes = [];
 
-            let timestamp = window.performance.now();
+            let timestamp = performance.now();
             this.segment._transitionTimestamp = timestamp;
 
             if (this.parentNode) {

--- a/src/renderer/RendererEvents.ts
+++ b/src/renderer/RendererEvents.ts
@@ -526,19 +526,19 @@ class RendererEvents extends Events<RendererEventsType> implements RendererEvent
 
     protected onMouseDown(sys: MouseEvent, event?: MouseHandlerEvent) {
         if (event!.button === input.MB_LEFT) {
-            this._lClkBegins = window.performance.now();
+            this._lClkBegins = performance.now();
             this._lclickX = event!.clientX;
             this._lclickY = event!.clientY;
             this.mouseState.sys = sys;
             this.mouseState.leftButtonDown = true;
         } else if (event!.button === input.MB_RIGHT) {
-            this._rClkBegins = window.performance.now();
+            this._rClkBegins = performance.now();
             this._rclickX = event!.clientX;
             this._rclickY = event!.clientY;
             this.mouseState.sys = sys;
             this.mouseState.rightButtonDown = true;
         } else if (event!.button === input.MB_MIDDLE) {
-            this._mClkBegins = window.performance.now();
+            this._mClkBegins = performance.now();
             this._mclickX = event!.clientX;
             this._mclickY = event!.clientY;
             this.mouseState.sys = sys;
@@ -549,7 +549,7 @@ class RendererEvents extends Events<RendererEventsType> implements RendererEvent
     protected onMouseUp(sys: MouseEvent, event?: MouseHandlerEvent) {
         let ms = this.mouseState;
         ms.sys = sys;
-        let t = window.performance.now();
+        let t = performance.now();
 
         if (event!.button === input.MB_LEFT) {
             ms.leftButtonDown = false;
@@ -561,13 +561,13 @@ class RendererEvents extends Events<RendererEventsType> implements RendererEvent
                 t - this._lClkBegins <= ms.clickDelay
             ) {
                 if (this._ldblClkBegins) {
-                    let deltatime = window.performance.now() - this._ldblClkBegins;
+                    let deltatime = performance.now() - this._ldblClkBegins;
                     if (deltatime <= ms.doubleClickDelay) {
                         ms.leftButtonDoubleClick = true;
                     }
                     this._ldblClkBegins = 0;
                 } else {
-                    this._ldblClkBegins = window.performance.now();
+                    this._ldblClkBegins = performance.now();
                 }
 
                 ms.leftButtonClick = true;
@@ -583,13 +583,13 @@ class RendererEvents extends Events<RendererEventsType> implements RendererEvent
                 t - this._rClkBegins <= ms.clickDelay
             ) {
                 if (this._rdblClkBegins) {
-                    let deltatime = window.performance.now() - this._rdblClkBegins;
+                    let deltatime = performance.now() - this._rdblClkBegins;
                     if (deltatime <= ms.doubleClickDelay) {
                         ms.rightButtonDoubleClick = true;
                     }
                     this._rdblClkBegins = 0;
                 } else {
-                    this._rdblClkBegins = window.performance.now();
+                    this._rdblClkBegins = performance.now();
                 }
 
                 ms.rightButtonClick = true;
@@ -605,13 +605,13 @@ class RendererEvents extends Events<RendererEventsType> implements RendererEvent
                 t - this._mClkBegins <= ms.clickDelay
             ) {
                 if (this._mdblClkBegins) {
-                    let deltatime = window.performance.now() - this._mdblClkBegins;
+                    let deltatime = performance.now() - this._mdblClkBegins;
                     if (deltatime <= ms.doubleClickDelay) {
                         ms.middleButtonDoubleClick = true;
                     }
                     this._mdblClkBegins = 0;
                 } else {
-                    this._mdblClkBegins = window.performance.now();
+                    this._mdblClkBegins = performance.now();
                 }
 
                 ms.middleButtonClick = true;
@@ -662,13 +662,13 @@ class RendererEvents extends Events<RendererEventsType> implements RendererEvent
 
             if (this._oneTouchStart) {
                 if (this._dblTchBegins) {
-                    let deltatime = window.performance.now() - this._dblTchBegins;
+                    let deltatime = performance.now() - this._dblTchBegins;
                     if (deltatime <= ts.doubleTouchDelay) {
                         ts.doubleTouch = true;
                     }
                     this._dblTchBegins = 0;
                 }
-                this._dblTchBegins = window.performance.now();
+                this._dblTchBegins = performance.now();
                 this._oneTouchStart = false;
             }
         }

--- a/src/segment/Segment.ts
+++ b/src/segment/Segment.ts
@@ -1744,8 +1744,8 @@ class Segment {
 
     public increaseTransitionOpacity() {
         //this._transitionOpacity += 0.01;
-        this._transitionOpacity += (window.performance.now() - this._transitionTimestamp) / this.planet.transitionTime;
-        this._transitionTimestamp = window.performance.now();
+        this._transitionOpacity += (performance.now() - this._transitionTimestamp) / this.planet.transitionTime;
+        this._transitionTimestamp = performance.now();
         if (this._transitionOpacity > 2.0) {
             this._transitionOpacity = 2.0;
         }
@@ -1770,8 +1770,8 @@ class Segment {
 
     public fadingTransitionOpacity() {
         this._transitionOpacity -= 0.01;
-        // this._transitionOpacity -= (window.performance.now() - this._transitionTimestamp) / this.planet.transitionTime;
-        this._transitionTimestamp = window.performance.now();
+        // this._transitionOpacity -= (performance.now() - this._transitionTimestamp) / this.planet.transitionTime;
+        this._transitionTimestamp = performance.now();
         if (this._transitionOpacity < 0.0) {
             this._transitionOpacity = 0;
         }

--- a/src/utils/NormalMapCreator.ts
+++ b/src/utils/NormalMapCreator.ts
@@ -375,7 +375,7 @@ export class NormalMapCreator {
             gl.disable(gl.BLEND);
 
             let deltaTime = 0,
-                startTime = window.performance.now();
+                startTime = performance.now();
 
             while (this._lock.isFree() && this._queue.length && deltaTime < 0.25) {
                 const segment = this._queue.shift()!;
@@ -387,7 +387,7 @@ export class NormalMapCreator {
                     segment.normalMapTextureBias[2] = 1;
                 }
                 segment._inTheQueue = false;
-                deltaTime = window.performance.now() - startTime;
+                deltaTime = performance.now() - startTime;
             }
 
             gl.enable(gl.BLEND);

--- a/src/utils/VectorTileCreator.ts
+++ b/src/utils/VectorTileCreator.ts
@@ -222,7 +222,7 @@ export class VectorTileCreator {
             let f = this._framebuffer!.activate();
 
             let deltaTime = 0,
-                startTime = window.performance.now();
+                startTime = performance.now();
 
             while (this._queue.length && deltaTime < MAX_FRAME_TIME) {
                 let material = this._queue.shift()!;
@@ -382,7 +382,7 @@ export class VectorTileCreator {
                     material.isLoading = false;
                 }
 
-                deltaTime = window.performance.now() - startTime;
+                deltaTime = performance.now() - startTime;
             }
 
             gl.enable(gl.DEPTH_TEST);

--- a/src/utils/raf.ts
+++ b/src/utils/raf.ts
@@ -1,0 +1,11 @@
+export const raf = (typeof window !== 'undefined' && window.requestAnimationFrame)
+    ? window.requestAnimationFrame.bind(window)
+    : (typeof self !== 'undefined' && (self as any).requestAnimationFrame)
+        ? (self as any).requestAnimationFrame.bind(self)
+        : (cb: FrameRequestCallback) => setTimeout(cb, 16);
+
+export const caf = (typeof window !== 'undefined' && window.cancelAnimationFrame)
+    ? window.cancelAnimationFrame.bind(window)
+    : (typeof self !== 'undefined' && (self as any).cancelAnimationFrame)
+        ? (self as any).cancelAnimationFrame.bind(self)
+        : (id: number) => clearTimeout(id);

--- a/src/webgl/Handler.ts
+++ b/src/webgl/Handler.ts
@@ -12,6 +12,7 @@ import {ProgramController} from "./ProgramController";
 import {Program} from "./Program";
 import {Stack} from "../Stack";
 import {throttle} from "../utils/shared";
+import {raf, caf} from "../utils/raf";
 
 export type WebGLContextExt = { type: string } & WebGL2RenderingContext;
 export type WebGLBufferExt = { numItems: number; itemSize: number } & WebGLBuffer;
@@ -1209,7 +1210,7 @@ class Handler {
      */
     public drawFrame = () => {
         /** Calculating frame time */
-        let now = window.performance.now();
+        let now = performance.now();
         let prevDeltaTime = this.deltaTime;
         //Make some filter:)
         this.deltaTime = (now - this._lastAnimationFrameTime + this.prevDeltaTime) * 0.5;
@@ -1233,7 +1234,7 @@ class Handler {
         if (Math.floor(canvas.clientWidth * this._params.pixelRatio) !== canvas.width || Math.floor(canvas.clientHeight * this._params.pixelRatio) !== canvas.height) {
             if (canvas.clientWidth === 0 || canvas.clientHeight === 0) {
                 this.stop();
-            } else if (!document.hidden) {
+            } else if (typeof document === "undefined" || !document.hidden) {
                 this.start();
                 this.setSize(canvas.clientWidth, canvas.clientHeight);
             }
@@ -1265,7 +1266,7 @@ class Handler {
 
     public stop() {
         if (this._requestAnimationFrameId) {
-            window.cancelAnimationFrame(this._requestAnimationFrameId);
+            caf(this._requestAnimationFrameId);
             this._requestAnimationFrameId = 0;
         }
     }
@@ -1287,7 +1288,7 @@ class Handler {
      * @protected
      */
     protected _animationFrameCallback() {
-        this._requestAnimationFrameId = window.requestAnimationFrame(() => {
+        this._requestAnimationFrameId = raf(() => {
             this._throttledDrawFrame();
             this._requestAnimationFrameId && this._animationFrameCallback();
         });


### PR DESCRIPTION
## Summary
- provide `raf`/`caf` helpers that work in Web Workers
- update `Handler` and timeline to use new helpers and `performance.now`
- remove `window` assumptions across the renderer
- add sandbox demo showing globe rendering in an offscreen worker

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685580240f8c83298b25d8313b1b783b